### PR TITLE
docs: fix Grafana port in mac-mini-setup cutover guide

### DIFF
--- a/docs/mac-mini-setup.md
+++ b/docs/mac-mini-setup.md
@@ -246,7 +246,7 @@ curl -s localhost:8080/metrics | head
 curl -s 'localhost:9090/api/v1/targets' | grep -o '"health":"[^"]*"'
 
 # Grafana: log in and confirm the dashboard loaded and its panels have data.
-open http://127.0.0.1:3000
+open http://127.0.0.1:9400
 ```
 
 Confirm the bot is back online in Discord and answers one slash command. Since this is


### PR DESCRIPTION
## Intent

Fix an operator-facing error in docs/mac-mini-setup.md: section 7 cutover dry run, step 2, told the operator to open http://127.0.0.1:3000 to check Grafana. The correct host port is 9400.

The one-line change is ALREADY COMMITTED at d6a48f2 and PR 26 is already open against master. There is nothing left to implement. This run exists only to put an already-shipped change through the validation pipeline it skipped on the fast path. Do not widen the diff to make it look busier. A clean run that finds nothing is an acceptable and expected outcome. If something on this branch is genuinely wrong, report it as a finding rather than quietly expanding the change.

Why 9400 is correct (already verified - do not re-derive, and do not revert it): docker-compose.yml:50 maps "127.0.0.1:9400:3000", so 3000 is the container-internal port only. The comment at docker-compose.yml:45-46 records that host port 9400 was chosen deliberately to sit outside the 3000-3010 range that local Node dev servers occupy. memory-progress.md:12 records the 2026-07-29 move, made after two Node dev servers were found holding port 3000: the forward lost the bind silently, so requests to 3000 were answered by an unrelated app while Grafana was healthy inside the compose network. README.md:16-33 already documents 9400, including a warning to use the literal IP rather than "localhost", which may resolve to IPv6 and reach a different app. Following the setup guide as written during a cutover therefore reproduces the exact silent wrong-app symptom that the 9400 move was made to prevent.

A deliberate decision worth knowing before flagging it: the "localhost:8080" (bot metrics) and "localhost:9090" (Prometheus targets) curl commands in that same code block were left as "localhost" on purpose, not by oversight. Both bind 127.0.0.1 only, and nothing else on this machine holds those ports, so a wrong IPv6 resolution is refused rather than silently answered by another app - unlike the Node collision that forced the Grafana move. If the review disagrees with that reasoning, the review wins: raise the finding rather than suppress it.

Also already checked by hand: the rest of docs/mac-mini-setup.md was read against docker-compose.yml, .github/workflows/deploy.yml, Dockerfile and .env.example. Bot port 8080, Prometheus port 9090, container name tbd-bot, the ~/tbd-bot-secrets/.env copy step, "docker compose up -d --build", the docker inspect health format, the 60s start period and 120s workflow timeout, the 256M memory limit, and the .env.example variable list all matched. No other drift was found. No test asserts the content of docs/mac-mini-setup.md; TestDocumentation_GrafanaAndRunnerSecurity in main_test.go reads README.md only.

Hard constraints that apply to every step of this run:

- DO NOT run docker, docker compose, docker build, colima, or launchctl. This machine is running the live Discord bot right now inside a Docker VM limited to 2 CPUs and 4 GB of RAM; a build or compose invocation competes with the running bot for memory it is already capped on. Verify port mappings and config by reading the files as text.
- DO NOT modify .dockerignore, main_test.go, AGENTS.md, or CLAUDE.md. A separate open PR (27) owns those files on its own branch, and touching them here creates a conflict for no reason.
- DO NOT modify docs/plans/2026-07-22-vps-migration.md or docs/specs/2026-07-22-vps-migration.md. Both say 3000, and both are dated records written before the 2026-07-29 move. They were accurate when written; they are history, not instructions.
- DO NOT touch .env, ~/tbd-bot-secrets/, or any credential.
- DO NOT merge PR 26, and do not close or reopen it. This run updates that same PR.

## What Changed

- In `docs/mac-mini-setup.md`, section 7 cutover dry run step 2, changed the Grafana check command from `open http://127.0.0.1:3000` to `open http://127.0.0.1:9400`, matching the host port mapping in `docker-compose.yml` (`127.0.0.1:9400:3000`).

## Risk Assessment

✅ Low: Single-line docs fix, port value verified against docker-compose.yml:50 mapping, no other files touched, no forbidden paths modified.

## Testing

Docs-only one-line port fix; no automated test covers docs/mac-mini-setup.md (confirmed TestDocumentation_GrafanaAndRunnerSecurity only reads README.md), and hard constraints forbid running docker/compose to exercise the guide live, so verification was manual cross-reference: diffed base against target, confirmed the changed URL's port matches docker-compose.yml's host-port mapping and comment rationale, confirmed README.md's already-published Grafana instructions agree, confirmed no other stray 3000 references remain in the doc, confirmed the two untouched localhost curl lines are correctly left as-is, and confirmed diff scope and forbidden-file list are respected. Worktree is clean, no artifacts to remove.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff de4c684..d6a48f2 -- docs/mac-mini-setup.md`
- `git diff --stat de4c684..d6a48f2`
- `git diff --name-only de4c684..d6a48f2 | grep against forbidden-file list`
- `grep -n '9400|3000' docker-compose.yml docs/mac-mini-setup.md`
- `manual read of docs/mac-mini-setup.md lines 235-254 for surrounding context`
- `grep -n '9400|127.0.0.1|localhost' README.md`
- `git status --short to confirm clean worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
