### PR TITLE
build: stop docs-only commits from rebuilding the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,18 @@
 
 # Ignore version control files
 .git
+
+# Docs, IDE metadata and monitoring config the bot image never reads. None of
+# these reach `go build`, `go test`, or the compiled binary at runtime, so
+# editing only these must not invalidate the `COPY . .` layer and restart the
+# live Discord bot on deploy.
+docs
+*.md
+grafana
+prometheus
+.idea
+tbd-bot.iml
+
+# Stale tracked binary; rebuilt by `go build -o tbd-bot .` in the builder
+# stage and never read from the source tree.
+/tbd-bot

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,17 +5,16 @@
 # Ignore version control files
 .git
 
-# Docs, IDE metadata and monitoring config the bot image never reads. None of
-# these reach `go build`, `go test`, or the compiled binary at runtime, so
-# editing only these must not invalidate the `COPY . .` layer and restart the
-# live Discord bot on deploy.
+# Docs and monitoring config the bot image never reads. None of these reach
+# `go build`, `go test`, or the compiled binary at runtime, so editing only
+# these must not invalidate the `COPY . .` layer and restart the live
+# Discord bot on deploy. grafana/ and prometheus/ are bind-mounted into
+# their own containers by docker-compose.yml, never copied into this image.
 docs
 *.md
 grafana
 prometheus
-.idea
-tbd-bot.iml
 
-# Stale tracked binary; rebuilt by `go build -o tbd-bot .` in the builder
-# stage and never read from the source tree.
+# Stale tracked binary (21MB); rebuilt by `go build -o tbd-bot .` in the
+# builder stage and never read from the source tree.
 /tbd-bot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+<!-- galdr:start -->
+<galdr-config path="docs/agents/galdr.md" />
+<!-- galdr:end -->
+
+## Docker build context
+
+`Dockerfile` copies the whole repo (`COPY . .`) and `deploy.yml` runs `docker compose up -d --build` on every push to master with no path filter, so anything not excluded in `.dockerignore` that changes will rebuild the image and restart the live bot.
+Keep `.dockerignore` in sync when adding files the Go build does not need (see `TestDockerignoreExcludesDocsButKeepsGoBuildInputs` in `main_test.go`, which fails if a doc file is left in or a Go build input is excluded).
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-<!-- galdr:start -->
-<galdr-config path="docs/agents/galdr.md" />
-<!-- galdr:end -->
+AGENTS.md

--- a/main_test.go
+++ b/main_test.go
@@ -865,12 +865,15 @@ func TestDockerignoreExcludesDocsButKeepsGoBuildInputs(t *testing.T) {
 	tracked := strings.Fields(string(out))
 
 	for _, f := range tracked {
-		isDoc := strings.HasSuffix(f, ".md") || strings.HasPrefix(f, "docs/")
-		if !isDoc {
+		isNonBuildInput := strings.HasSuffix(f, ".md") ||
+			strings.HasPrefix(f, "docs/") ||
+			strings.HasPrefix(f, "grafana/") ||
+			strings.HasPrefix(f, "prometheus/")
+		if !isNonBuildInput {
 			continue
 		}
 		if !anyDockerignorePatternMatches(patterns, f) {
-			t.Errorf(".dockerignore does not exclude documentation file %q; a doc-only commit would still invalidate the build context and restart the bot", f)
+			t.Errorf(".dockerignore does not exclude %q; a commit touching only docs/grafana/prometheus would still invalidate the build context and restart the bot", f)
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -805,5 +806,81 @@ func TestDeployWorkflowReloadsGrafanaProvisioning(t *testing.T) {
 	// deploy to pick up a Grafana-only change.
 	if strings.Contains(workflow, "docker compose restart\n") || strings.Contains(workflow, "docker compose restart tbd-bot") {
 		t.Error("deploy.yml restarts more than Grafana; a provisioning change must not cost bot downtime")
+	}
+}
+
+// dockerignoreMatches reimplements the directory-prefix semantics dockerd
+// uses for plain (non-**) .dockerignore patterns: a pattern excludes a path
+// if its components glob-match a PREFIX of the path's components, so "docs"
+// (one component) excludes the whole subtree, while "*.md" (also one
+// component) only ever matches root-level files, never nested ones.
+func dockerignoreMatches(pattern, path string) bool {
+	patParts := strings.Split(strings.Trim(pattern, "/"), "/")
+	pathParts := strings.Split(path, "/")
+	if len(patParts) > len(pathParts) {
+		return false
+	}
+	for i, p := range patParts {
+		if ok, err := filepath.Match(p, pathParts[i]); err != nil || !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func anyDockerignorePatternMatches(patterns []string, path string) bool {
+	for _, pattern := range patterns {
+		if dockerignoreMatches(pattern, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// deploy.yml runs `docker compose up -d --build` on every push to master
+// with no path filter, and Dockerfile:14 is `COPY . .`, so anything left in
+// the build context that changes invalidates that layer and restarts the
+// live bot. This test pins both directions of .dockerignore: docs and
+// markdown must stay excluded (the regression this guards), and no pattern
+// may reach a file the Go build actually needs, since that would silently
+// ship a broken image.
+func TestDockerignoreExcludesDocsButKeepsGoBuildInputs(t *testing.T) {
+	ignoreBytes, err := os.ReadFile(".dockerignore")
+	if err != nil {
+		t.Fatalf("failed to read .dockerignore: %v", err)
+	}
+	var patterns []string
+	for _, line := range strings.Split(string(ignoreBytes), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+
+	out, err := exec.Command("git", "ls-files").Output()
+	if err != nil {
+		t.Fatalf("git ls-files failed: %v", err)
+	}
+	tracked := strings.Fields(string(out))
+
+	for _, f := range tracked {
+		isDoc := strings.HasSuffix(f, ".md") || strings.HasPrefix(f, "docs/")
+		if !isDoc {
+			continue
+		}
+		if !anyDockerignorePatternMatches(patterns, f) {
+			t.Errorf(".dockerignore does not exclude documentation file %q; a doc-only commit would still invalidate the build context and restart the bot", f)
+		}
+	}
+
+	for _, f := range tracked {
+		isBuildInput := f == "go.mod" || f == "go.sum" || strings.HasSuffix(f, ".go")
+		if !isBuildInput {
+			continue
+		}
+		if anyDockerignorePatternMatches(patterns, f) {
+			t.Errorf(".dockerignore excludes %q, which `go build -o tbd-bot .` needs; the image would fail to build on deploy", f)
+		}
 	}
 }


### PR DESCRIPTION
## Intent

Stop documentation-only commits from rebuilding the tbd-bot Docker image and restarting the live Discord bot. Root cause: .github/workflows/deploy.yml triggers on push to master with no path filter and runs docker compose up -d --build; Dockerfile:14 is COPY . ., so the whole repo is the build context; .dockerignore only excluded /bin, /pkg, .git. Editing docs/ or any .md file therefore changed the build context, invalidated the COPY . . layer, produced a new image, and restarted the tbd-bot container even for a pure typo fix.

Fix: exclude from the Docker build context everything the bot image does not need. Starting candidates given were docs/, *.md, grafana/, prometheus/ - confirmed myself (not assumed) that grafana/ and prometheus/ are bind-mounted into their own containers by docker-compose.yml at runtime and never copied into the bot image. Verified via grep that no non-test Go code does go:embed or os.ReadFile/os.Open of any local file (config is compiled-in Go source, not loaded from disk), so nothing under docs/ or any *.md is read by the build or by the running binary. README.md is read only by main_test.go via os.ReadFile during host go test, which never runs inside the Dockerfile (the builder stage only runs go build, not go test), so excluding it from the Docker build context is safe.

Deliberately did NOT exclude .idea/ or tbd-bot.iml - reconsidered after initially adding them, dropped them because they don't churn on the documentation-only-commit defect this task targets, and every .dockerignore entry should be justifiable against that specific defect.

Did add /tbd-bot to .dockerignore: a 21MB compiled binary that is tracked in git at the repo root. It is never read by the build (the builder stage produces its own binary via go build -o tbd-bot . and the final stage copies that fresh one) or by the running container, so it is pure build-context bloat on every build. This is a related but separate concern from the documentation-restart defect - call it out as such if review raises it.

Final .dockerignore additions: docs, *.md, grafana, prometheus, /tbd-bot - each with an inline comment justifying it.

Testing requirement: main_test.go pins literal strings for docker-compose.yml and the GitHub workflow files already; task required checking whether an existing or new test should cover .dockerignore/Dockerfile/build-context and adding one if not. Added TestDockerignoreExcludesDocsButKeepsGoBuildInputs in main_test.go. It parses .dockerignore into patterns, reimplements dockerd's plain (non-**) prefix-matching semantics for .dockerignore patterns (a single-component pattern like *.md only matches root-level files, not nested ones, while a bare directory-name pattern like docs excludes the whole subtree), reads tracked files via git ls-files, and asserts two directions: (1) every tracked path under docs/, grafana/, prometheus/, or ending in .md is matched by some .dockerignore pattern, and (2) go.mod, go.sum, and every tracked .go file are matched by none. I manually verified both directions of this test actually fire: temporarily removing the grafana line made the test fail, and temporarily appending *.go to .dockerignore made the test fail on main.go and main_test.go; both were reverted before committing.

Hard constraints from the task, respected: did not run docker/docker compose/docker build/colima/launchctl (host has a memory-constrained Docker VM running the live bot); did not change deploy.yml, docker-compose.yml, or Dockerfile - only .dockerignore and main_test.go; did not touch docs/mac-mini-setup.md (held by another worker on a separate branch); did not touch .env, ~/tbd-bot-secrets/, or any credential.

Verification already run and green on host Go (no Docker): go build ./... and go test ./... both pass.

Separable change bundled in the same branch: ran the project's fm-ensure-agents-md.sh housekeeping script, which promoted the existing CLAUDE.md into AGENTS.md (CLAUDE.md is now a symlink to AGENTS.md, a pre-existing repo convention already present in AGENTS.md's own "Maintaining this file" section) and added a short new AGENTS.md section docum689ing the COPY . . / docker compose up -d --build interaction and pointing at the new test, so future agents keep .dockerignore in sync with what the Go build needs. Note: .dockerignore's *.md pattern now also excludes the CLAUDE.md symlink and its AGENTS.md target - confirmed inert since nothing in the build or runtime binary follows or reads either file.

## What Changed

- Added `docs`, `*.md`, `grafana`, `prometheus`, and `/tbd-bot` to `.dockerignore` so the Docker build context no longer includes files the bot image never reads at build or runtime; each entry has an inline comment justifying it.
- Added `TestDockerignoreExcludesDocsButKeepsGoBuildInputs` in `main_test.go`, which parses `.dockerignore`, reimplements dockerd's prefix-matching semantics for plain patterns, and asserts every tracked file under `docs/`, `grafana/`, `prometheus/`, or ending in `.md` is excluded while `go.mod`, `go.sum`, and all `.go` files remain included.
- Promoted `CLAUDE.md` into `AGENTS.md` (new file) and replaced `CLAUDE.md` with a symlink to it, adding a new section documenting the `COPY . .` / `docker compose up -d --build` interaction and pointing future agents at the new test.

## Risk Assessment

✅ Low: Diff scoped to .dockerignore + doc promotion + test; verified grafana/prometheus bind-mounted (not copied), no go:embed/os.ReadFile of docs/md outside test, Dockerfile builder never runs go test, .idea/tbd-bot.iml correctly left untouched, deploy.yml/docker-compose.yml/Dockerfile untouched, new test parses .dockerignore into a semantic pattern model (not raw substring match) and checks real git-tracked files both directions.

## Testing

Reproduced the regression directly: the new test fails on the pre-fix .dockerignore (docs/grafana/prometheus/*.md all unexcluded) and passes on the fix, plus go build and all related Dockerfile/deploy/compose tests pass; docker build itself was intentionally not run per the stated host constraint (memory-constrained VM running the live bot).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go build ./...`
- `go test ./... -run 'TestDockerignoreExcludesDocsButKeepsGoBuildInputs|TestDeployWorkflowReloadsGrafanaProvisioning|TestDockerCompose|TestDeployWorkflow|Dockerfile' -v`
- `Manual regression check: swapped in base commit's .dockerignore, reran TestDockerignoreExcludesDocsButKeepsGoBuildInputs -> FAIL (16 unexcluded paths listed), restored target .dockerignore, reran -> PASS`
- `grep for go:embed / os.ReadFile / os.Open in non-test .go files -> none, confirming docs/*.md are not read by build or runtime`
- <code>Inspected docker-compose.yml: grafana and prometheus services use official images with read-only bind mounts, never `build: context: .`</code>
- <code>Inspected Dockerfile: builder stage runs only `go build -o tbd-bot .`, never `go test`, confirming README.md exclusion (read only by main_test.go) is safe</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
